### PR TITLE
docs: Add polarization labeling analysis and reference documents

### DIFF
--- a/.claude/docs/issue-polarization-type-labeling.md
+++ b/.claude/docs/issue-polarization-type-labeling.md
@@ -1,0 +1,236 @@
+# Issue: PolarizationType and PMType Labeling
+
+## Problem Summary
+
+The `PolarizationType` enum uses "Ordinary" and "Extraordinary" labels, but the
+Fresnel equation solver in `CrystalSetup::index_along()` actually implements a
+**fast/slow** mapping that is only correct for negative uniaxial crystals. This
+creates conceptual confusion, prevents correct handling of positive uniaxial
+and custom expression crystals, and is missing PM types needed for certain
+biaxial crystal interactions.
+
+See [polarization-conventions-in-nonlinear-optics.md](polarization-conventions-in-nonlinear-optics.md)
+for the physics background.
+
+## Current Behavior
+
+### The Fresnel Solver (`crystal_setup.rs:73-85`)
+
+The `index_along()` method solves a quadratic (Eq. 11 from the NIST
+phasematching paper) for the two refractive index eigenvalues along a given
+propagation direction. The two roots always map as:
+
+```
+PolarizationType::Ordinary      -> high-n root (SLOW wave)
+PolarizationType::Extraordinary -> low-n root  (FAST wave)
+```
+
+**The inline comments (lines 78-81) have fast/slow reversed.** They say
+"fast" for Ordinary and "slow" for Extraordinary, but the math gives the
+opposite. Verified numerically with BBO and KTP.
+
+### Why 77 tests pass
+
+All existing tests use either:
+- Negative uniaxial crystals (BBO, LiNbO3) where ordinary = slow and
+  extraordinary = fast — matching the code's convention
+- Biaxial crystals (KTP) where there is no physical "ordinary"/"extraordinary"
+  and the fast/slow mapping is internally consistent
+
+The convention works because the PM type labels are interpreted consistently
+with the solver: `e` always means "fast" and `o` always means "slow",
+regardless of crystal type.
+
+### Why the expression crystal test fails
+
+The test `index_along_expr_crystal_test` creates a positive uniaxial crystal
+with `no=1, ne=2` (indices `[1, 1, 2]`). It expects:
+
+```
+Extraordinary -> 2.0 (the ne value)
+Ordinary      -> 1.0 (the no value)
+```
+
+But the code returns the opposite because it maps Extraordinary -> fast(low-n)
+= 1.0 and Ordinary -> slow(high-n) = 2.0. The test was added in commit
+78d297b as part of an attempted fix that was reverted in 85a2350 because
+changing the solver broke all other tests.
+
+### Missing PM Types
+
+The enum only supports pump-fast configurations:
+
+```rust
+Type0_o_oo,   // pump slow, daughters slow
+Type0_e_ee,   // pump fast, daughters fast
+Type1_e_oo,   // pump fast, daughters slow
+Type2_e_eo,   // pump fast, signal fast, idler slow
+Type2_e_oe,   // pump fast, signal slow, idler fast
+```
+
+Missing pump-slow-with-mixed-daughters types:
+
+```
+Type1_o_ee    // pump slow, daughters fast    (needed for d_32 in ppKTP)
+Type2_o_oe    // pump slow, signal slow, idler fast
+Type2_o_eo    // pump slow, signal fast, idler slow
+```
+
+For ppKTP (propagation along X), the d_32 coefficient (~2.4 pm/V) enables
+a Type I interaction: pump(Z/slow) -> signal(Y/fast) + idler(Y/fast). This
+cannot be expressed with the current PMType enum.
+
+## Mapping Between Conventions
+
+For reference, here is how the current code labels translate to standard
+conventions for common configurations:
+
+### BBO (negative uniaxial, n_o > n_e)
+
+| Code label | Physical meaning | Standard convention |
+|---|---|---|
+| `Ordinary` | n_o (slow, high-n) | Ordinary (correct) |
+| `Extraordinary` | n_e (fast, low-n) | Extraordinary (correct) |
+| `e->oo` (Type I) | pump(e/fast) -> daughters(o/slow) | Type I: `e->oo` (correct) |
+| `e->eo` (Type II) | pump(e/fast) -> sig(e/fast) + idl(o/slow) | Type II: `e->eo` (correct) |
+
+### KTP at theta=90 (biaxial, propagation along crystal X)
+
+| Code label | Physical meaning | Standard biaxial convention |
+|---|---|---|
+| `Ordinary` | n_z = 1.830 (slow, Z-polarized) | Slow |
+| `Extraordinary` | n_y = 1.747 (fast, Y-polarized) | Fast |
+| `o->oo` (Type 0) | all Z/slow, uses d_33 | `s->ss` |
+| `e->eo` (Type II) | pump(Y/fast) -> sig(Y/fast) + idl(Z/slow), uses d_24 | `f->fs` |
+| N/A (missing) | pump(Z/slow) -> sig(Y/fast) + idl(Y/fast), uses d_32 | `s->ff` |
+
+### Positive uniaxial crystal (e.g., custom no=1, ne=2)
+
+| Code label | Physical meaning | Standard convention |
+|---|---|---|
+| `Ordinary` | ne = 2 (slow, high-n) | **Extraordinary** (WRONG) |
+| `Extraordinary` | no = 1 (fast, low-n) | **Ordinary** (WRONG) |
+
+This is the source of the failing test and conceptual confusion.
+
+## Recommendations
+
+### Phase 1: Immediate fixes (no behavioral changes, no API breakage)
+
+1. **Fix the comments** in `index_along` (lines 78-81):
+   ```rust
+   // slow (higher refractive index)
+   PolarizationType::Ordinary => -x2,
+   // fast (lower refractive index)
+   PolarizationType::Extraordinary => -x1,
+   ```
+
+2. **Fix the failing test** to match the actual code convention. The test
+   expectations should be swapped, or (better) the test should be rewritten
+   to demonstrate the actual mapping with a clear comment explaining why
+   `Ordinary` gives the `ne` value for this positive uniaxial crystal.
+
+3. **Add documentation** to `PolarizationType` and `PMType` explaining the
+   actual semantics:
+   ```rust
+   /// The polarization eigenmode type.
+   ///
+   /// **Important**: In this codebase, `Ordinary` always selects the eigenmode
+   /// with the *higher* refractive index (the "slow" wave), and `Extraordinary`
+   /// always selects the eigenmode with the *lower* refractive index (the "fast"
+   /// wave). This matches the standard physics convention for negative uniaxial
+   /// crystals (like BBO), but is reversed for positive uniaxial crystals and
+   /// does not correspond to the physical ordinary/extraordinary distinction
+   /// for biaxial crystals.
+   ///
+   /// For biaxial crystals, think of `Ordinary` as "slow" and `Extraordinary`
+   /// as "fast".
+   ```
+
+### Phase 2: Add fast/slow aliases (backward-compatible)
+
+1. **Add string aliases** to `PolarizationType::from_str`:
+   - `"s"` / `"slow"` -> `Ordinary` (slow)
+   - `"f"` / `"fast"` -> `Extraordinary` (fast)
+
+2. **Add string aliases** to `PMType::from_str`:
+   - `"s->ss"` -> `Type0_o_oo`
+   - `"f->ff"` -> `Type0_e_ee`
+   - `"f->ss"` -> `Type1_e_oo`
+   - `"f->fs"` -> `Type2_e_eo`
+   - `"f->sf"` -> `Type2_e_oe`
+
+3. **Add the missing PM types** to the enum:
+   ```rust
+   Type1_o_ee,   // s->ff: pump slow, daughters fast
+   Type2_o_oe,   // s->sf: pump slow, signal slow, idler fast
+   Type2_o_eo,   // s->fs: pump slow, signal fast, idler slow
+   ```
+   With corresponding string parsing for both `o`/`e` and `s`/`f` notations.
+
+### Phase 3: Rename to fast/slow (breaking API change, major version)
+
+1. **Rename** `PolarizationType` variants:
+   ```rust
+   pub enum PolarizationType {
+     /// Eigenmode with lower refractive index (faster phase velocity).
+     Fast,
+     /// Eigenmode with higher refractive index (slower phase velocity).
+     Slow,
+   }
+   ```
+
+2. **Rename** `PMType` variants:
+   ```rust
+   pub enum PMType {
+     Type0_s_ss,   // All slow
+     Type0_f_ff,   // All fast
+     Type1_f_ss,   // Pump fast, daughters slow
+     Type1_s_ff,   // Pump slow, daughters fast
+     Type2_f_fs,   // Pump fast, signal fast, idler slow
+     Type2_f_sf,   // Pump fast, signal slow, idler fast
+     Type2_s_sf,   // Pump slow, signal slow, idler fast
+     Type2_s_fs,   // Pump slow, signal fast, idler slow
+   }
+   ```
+
+3. **Keep backward compatibility** in parsing: `"e->eo"` still parses to
+   `Type2_f_fs`, `"o->oo"` still parses to `Type0_s_ss`.
+
+4. **Coordinate with downstream**: spdcalc-ui and spdcalc-py depend on the
+   public API. The serialized form should remain backward-compatible (accept
+   old format on input, emit new format on output).
+
+### Optional Enhancements
+
+- **Principal-axis notation for QPM**: Accept `"Y->YZ"` or `"Z->ZZ"` as PM
+  type strings when theta=90 (propagation along a principal axis). This is
+  natural for the ppKTP/ppLN community.
+
+- **PM type validation**: Warn or error when a PM type has zero effective
+  nonlinear coefficient for the given crystal symmetry and orientation (e.g.,
+  `Type0_f_ff` / all-Y in KTP is forbidden because d_222 = 0 for mm2).
+
+- **Display methods**: Add a method that returns the PM type in the
+  crystal-axis notation (e.g., `"Y->YZ"`) given the crystal setup, for use in
+  UI display and logging.
+
+## Impact Assessment
+
+### Phase 1 (immediate fixes)
+- No behavioral changes
+- No API breakage
+- Fixes 1 failing test
+- Improves developer understanding
+
+### Phase 2 (aliases + missing types)
+- Backward-compatible addition
+- Enables new physics (d_32 interactions, positive uniaxial crystals with
+  correct labeling via f/s notation)
+- Minor additions to spdcalc-py to expose new types
+
+### Phase 3 (rename)
+- Breaking API change (major version bump)
+- Requires updates to spdcalc-ui and spdcalc-py
+- Significant improvement to conceptual clarity
+- Aligns with established nonlinear optics conventions

--- a/.claude/docs/polarization-conventions-in-nonlinear-optics.md
+++ b/.claude/docs/polarization-conventions-in-nonlinear-optics.md
@@ -1,0 +1,201 @@
+# Polarization Conventions in Nonlinear Optics
+
+Reference document covering the standard conventions for labeling polarization
+eigenmodes in nonlinear optical crystals, with emphasis on SPDC source design.
+This document captures research into textbook definitions, community standards,
+and how they relate to the spdcalc codebase.
+
+## Uniaxial Crystals: Ordinary and Extraordinary
+
+Uniaxial crystals (e.g., BBO, LiNbO3) have a single optic axis (conventionally
+the Z-axis) and two principal refractive indices:
+
+- **Ordinary (o)**: polarization perpendicular to the optic axis; refractive
+  index `n_o` is independent of propagation direction.
+- **Extraordinary (e)**: polarization in the plane containing the optic axis and
+  the propagation direction; refractive index `n_e(theta)` depends on the angle
+  theta between the propagation direction and the optic axis.
+
+Two sub-types based on index ordering:
+
+| Type | Index relation | Example crystals |
+|---|---|---|
+| **Negative uniaxial** | n_o > n_e | BBO, LiNbO3, KDP |
+| **Positive uniaxial** | n_o < n_e | Quartz |
+
+For negative uniaxial: ordinary = slow (high n), extraordinary = fast (low n).
+For positive uniaxial: ordinary = fast (low n), extraordinary = slow (high n).
+
+## Biaxial Crystals: Fast and Slow
+
+Biaxial crystals (e.g., KTP, KTA, LBO, BiBO) have three distinct principal
+refractive indices along three orthogonal crystal axes:
+
+```
+n_x < n_y < n_z    (standard convention, IEEE/ANSI Std. 176)
+```
+
+For biaxial crystals, the terms "ordinary" and "extraordinary" **do not have
+rigorous physical meaning**. Instead, the two polarization eigenmodes for a
+given propagation direction are labeled:
+
+- **Fast (f)**: the eigenmode with the lower refractive index (higher phase
+  velocity)
+- **Slow (s)**: the eigenmode with the higher refractive index (lower phase
+  velocity)
+
+This convention is used by:
+- Dmitriev, Gurzadyan, Nikogosyan: *Handbook of Nonlinear Optical Crystals*
+  (Springer)
+- Smith, A.V.: *Crystal Nonlinear Optics with SNLO Examples* (uses "lo"/"hi")
+- Boeuf, Migdall et al., NIST phasematching code (Optical Engineering, 2000)
+- Roberts, D.A.: "Simplified characterization of uniaxial and biaxial nonlinear
+  optical crystals" (IEEE J. Quantum Electron. 28, 2057, 1992) — the closest
+  document to a formal standard
+
+Many SPDC papers still informally use "o" and "e" for biaxial crystals by
+analogy, but this is a **convention of convenience**, not a physically precise
+description.
+
+## Phase-Matching Type Classification
+
+### General Definition
+
+| Type | Definition (for downconversion: pump -> signal + idler) |
+|---|---|
+| **Type 0** | All three waves have the same polarization |
+| **Type I** | Signal and idler have the same polarization, different from pump |
+| **Type II** | Signal and idler have orthogonal polarizations |
+
+### Notation for Uniaxial Crystals
+
+Uses `o` and `e`:
+
+- Type 0: `o->oo` or `e->ee`
+- Type I: `e->oo` (negative uniaxial) or `o->ee` (positive uniaxial)
+- Type II: `e->eo`, `e->oe` (negative uniaxial) or `o->oe`, `o->eo` (positive
+  uniaxial)
+
+### Notation for Biaxial Crystals
+
+Uses `s` (slow) and `f` (fast):
+
+- Type 0: `s->ss` (all slow) or `f->ff` (all fast)
+- Type I: `f->ss` (pump fast, daughters slow) or `s->ff` (pump slow, daughters
+  fast)
+- Type II: `f->fs`, `f->sf` (pump fast) or `s->sf`, `s->fs` (pump slow)
+
+### Type 0 and Quasi-Phase-Matching
+
+Type 0 phase matching (all same polarization) **cannot be achieved with
+birefringent phase matching** — it requires quasi-phase-matching (QPM) via
+periodic poling. The advantage is access to the largest nonlinear coefficient
+(e.g., d_33 in both LiNbO3 and KTP).
+
+## QPM in Periodically Poled Crystals
+
+For quasi-phase-matching with periodic poling, propagation is along a principal
+crystal axis. This simplifies the eigenmodes to pure principal-axis
+polarizations.
+
+### ppKTP (propagation along crystal X-axis)
+
+For KTP with theta=90deg, phi=0deg, propagation is along the crystal X-axis.
+The two eigenmodes are:
+
+| Eigenmode | Polarization direction | Index | Wave type |
+|---|---|---|---|
+| Y-polarized | Crystal Y-axis | n_y (middle) | **Fast** |
+| Z-polarized | Crystal Z-axis | n_z (highest) | **Slow** |
+
+The physically allowed interactions (determined by KTP's mm2 point group
+symmetry and the d-tensor) for collinear propagation along X are:
+
+| d coefficient | Value | Interaction | PM Type |
+|---|---|---|---|
+| d_33 | ~10.7 pm/V | Z->ZZ (all slow) | Type 0: `s->ss` |
+| d_24 | ~3.64 pm/V | Y->YZ (fast->fast+slow) | Type II: `f->fs` |
+| d_32 | ~2.4 pm/V | Z->YY (slow->fast+fast) | Type I: `s->ff` |
+
+The d_24 interaction (Type II) is the most commonly used for polarization-
+entangled photon pair generation in ppKTP.
+
+### ppLN (propagation perpendicular to crystal Z-axis)
+
+For LiNbO3 (negative uniaxial, n_o > n_e), the standard QPM configuration
+propagates perpendicular to the optic axis (Z). All beams polarized along Z
+access d_33 (~27 pm/V), giving Type 0: `e->ee`.
+
+## KTP Crystal Specifics
+
+KTP (KTiOPO4) is a **positive biaxial** crystal with orthorhombic mm2 point
+symmetry. Crystallographic axes a, b, c correspond to optical axes X, Y, Z:
+
+```
+n_x(1550nm) ~ 1.740    (a-axis)
+n_y(1550nm) ~ 1.747    (b-axis)
+n_z(1550nm) ~ 1.830    (c-axis)
+```
+
+For Type II SPDC in ppKTP (the standard entangled photon source configuration):
+- Propagation along X (crystal a-axis)
+- Pump: Y-polarized (fast, n_y) — labeled H in lab frame
+- Signal: Y-polarized (fast, n_y) — labeled H
+- Idler: Z-polarized (slow, n_z) — labeled V
+- Nonlinear coefficient: d_24
+- The birefringence (n_z - n_y) creates temporal walk-off between H and V
+  photons
+
+## Crystal Theta Convention in spdcalc
+
+Setting `theta_deg: 90` with `phi_deg: 0` in spdcalc applies a rotation
+`R_y(90deg)` to map between lab and crystal frames:
+
+```
+Lab Z (propagation) -> Crystal X
+Lab Y               -> Crystal Y  (unchanged)
+Lab X               -> Crystal -Z
+```
+
+This is the standard configuration for collinear QPM in ppKTP and ppLN: the
+beam propagates along the crystal X-axis, and the crystal Z-axis (the poling
+direction) lies perpendicular to propagation in the lab horizontal plane.
+
+## Formal Standards
+
+There is no single unified IEEE/OSA/SPIE standard for polarization labeling in
+nonlinear optics. The closest references are:
+
+1. **IEEE/ANSI Std. 176-1987** (Standard on Piezoelectricity): Defines
+   crystallographic axis conventions. Widely adopted for crystal orientation.
+
+2. **Roberts (1992)**, IEEE J. Quantum Electron. 28, 2057: "A plea for
+   standardization of nomenclature and conventions." Proposes the Positive
+   Nonlinear Optics Frame, recommends IEEE Std. 176 with a modification for
+   mm2 crystals.
+
+3. **Hobden (1967)**, J. Appl. Phys. 38, 4365: Original classification of
+   phase-matched SHG directions in biaxial crystals (up to 72 classes).
+
+The de facto community convention:
+- Uniaxial crystals: `o`/`e`
+- Biaxial crystals: `f`/`s` (or equivalently `lo`/`hi`)
+- Index ordering: `n_x < n_y < n_z` for biaxial
+- Type I/II defined by whether the two lower-frequency waves share the same or
+  different polarization
+
+## Key References
+
+- Boyd, R.W. *Nonlinear Optics* (4th ed., Academic Press) — standard textbook;
+  primarily covers uniaxial crystals
+- Dmitriev, V.G., Gurzadyan, G.G., Nikogosyan, D.N. *Handbook of Nonlinear
+  Optical Crystals* (Springer) — uses f/s for biaxial; comprehensive crystal
+  data
+- Smith, A.V. *Crystal Nonlinear Optics with SNLO Examples* — uses hi/lo index
+  surfaces
+- Roberts, D.A. IEEE J. Quantum Electron. 28, 2057 (1992) — standardization
+  proposal
+- Boeuf et al. Opt. Eng. 39, 1016 (2000) — NIST phasematching code; uses f/s
+  for biaxial
+- Couteau, C. "Spontaneous parametric down-conversion" (arXiv:1809.00127) —
+  SPDC review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,5 +277,27 @@ This library is the backbone of two other spdcalc libraries:
 
 **Important:** Any modifications should take into account that those libraries depend on spdcalc and would break if the API changes, so breaking API changes should be called out.
 
+## Known Issues
+
+- **Polarization labeling**: `PolarizationType::Ordinary`/`Extraordinary` and
+  `PMType` labels use uniaxial crystal terminology but actually implement a
+  fast/slow wave mapping. This is correct for negative uniaxial crystals (BBO)
+  but conceptually wrong for biaxial (KTP) and positive uniaxial crystals. The
+  Fresnel solver in `CrystalSetup::index_along()` always maps `Ordinary` to the
+  slow (high-n) root and `Extraordinary` to the fast (low-n) root. See
+  [.claude/docs/issue-polarization-type-labeling.md](.claude/docs/issue-polarization-type-labeling.md)
+  for the full analysis and recommended fix path.
+
+## Reference Documents
+
+- [Polarization Conventions in Nonlinear Optics](.claude/docs/polarization-conventions-in-nonlinear-optics.md):
+  Standard conventions for labeling polarization eigenmodes in uniaxial and
+  biaxial crystals, phase-matching type classification, QPM configurations,
+  and key references from the nonlinear optics literature.
+- [Polarization Type Labeling Issue](.claude/docs/issue-polarization-type-labeling.md):
+  Detailed analysis of the `PolarizationType`/`PMType` naming problem, the
+  failing expression crystal test, missing PM types, and a phased plan for
+  fixing the issue.
+
 ## Other notes
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation analyzing the polarization type labeling issue in spdcalc and establishes reference materials for nonlinear optics conventions.

## Changes

- **Added `.claude/docs/issue-polarization-type-labeling.md`**: Detailed analysis of the `PolarizationType` and `PMType` labeling problem, including:
  - Root cause: The Fresnel solver implements a fast/slow mapping that is only correct for negative uniaxial crystals, but uses uniaxial terminology (`Ordinary`/`Extraordinary`)
  - Why 77 tests pass: All existing tests use negative uniaxial or biaxial crystals where the convention is internally consistent
  - Why the expression crystal test fails: Positive uniaxial crystals have reversed semantics
  - Missing PM types needed for certain biaxial interactions (e.g., `Type1_o_ee` for d_32 in ppKTP)
  - Mapping tables showing how current labels translate to standard conventions for BBO, KTP, and positive uniaxial crystals
  - Three-phase remediation plan: immediate fixes (comments + documentation), backward-compatible aliases and missing types, and eventual rename to fast/slow

- **Added `.claude/docs/polarization-conventions-in-nonlinear-optics.md`**: Reference document covering:
  - Standard conventions for uniaxial (ordinary/extraordinary) and biaxial (fast/slow) crystals
  - Phase-matching type classification (Type 0/I/II) and notation
  - Quasi-phase-matching in periodically poled crystals with ppKTP and ppLN examples
  - KTP crystal specifics and the standard entangled photon source configuration
  - Crystal theta convention used in spdcalc
  - Formal standards and de facto community conventions
  - Key references from nonlinear optics literature

- **Updated `CLAUDE.md`**: Added "Known Issues" section documenting the polarization labeling problem and "Reference Documents" section linking to the new documentation.

## Notes

These are documentation-only changes that do not modify any source code behavior. They establish the foundation for addressing the polarization labeling issue identified in the failing `index_along_expr_crystal_test` and provide context for future API improvements.

https://claude.ai/code/session_01LobQFHYAZ9KSB89LoE1Z2t